### PR TITLE
精准匹配+苛刻匹配度

### DIFF
--- a/WeiBanHelper.py
+++ b/WeiBanHelper.py
@@ -205,7 +205,7 @@ class WeibanHelper:
             answer_data = json.loads(f.read())
 
         def get_answer_list(question_title):
-            closest_match = difflib.get_close_matches(question_title, answer_data.keys(), n=1, cutoff=0.8)
+            closest_match = difflib.get_close_matches(question_title, answer_data.keys(), n=1, cutoff=1)
             answer_list = []
             if closest_match:
                 data = answer_data[closest_match[0]]
@@ -295,7 +295,7 @@ class WeibanHelper:
                           headers=self.headers, data=record_data)
         # SubMit
         print("答案匹配度: ", match_count, " / ", len(question_list))
-        if len(question_list) - match_count >= 5:
+        if len(question_list) - match_count >= 1:
             print("题库匹配度过低")
             print("暂未提交,请重新考试")
             return


### PR DESCRIPTION
解决匹配度50/50，但不满分的问题，苛刻匹配度不满分不提交。

匹配度50/50，但不满分问题原因：当cutoff不为1，且>0.6时，题库题干匹配方式为:只要有足量的内容相同就视为匹配并给is_match赋值true，导致最终匹配计数50/50，但实际未匹配到题目，且没有进行作答，导致空题扣分。